### PR TITLE
feature: add docker build & push to ghcr

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,5 +15,5 @@ jobs:
       with:
         image: ${{ env.IMAGENAME }}
         registry: ${{ env.REGISTRY }}
-        username: ${{ secrets.GHCR_USERNAME }}
-        password: ${{ secrets.GHCR_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -15,5 +15,5 @@ jobs:
       with:
         image: ${{ env.IMAGENAME }}
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,0 +1,19 @@
+name: Docker build & push
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    env:
+      REGISTRY: ghcr.io
+      IMAGENAME: ${{ github.event.repository.name }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Docker build
+      uses: mr-smithers-excellent/docker-build-push@v5
+      with:
+        image: ${{ env.IMAGENAME }}
+        registry: ${{ env.REGISTRY }}
+        username: ${{ secrets.GHCR_USERNAME }}
+        password: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
For this feature to work, we should add 2 secrets to the repository:

- `GHCR_TOKEN`: a Personal Access Token with `write:packages` scope.
- `GHCR_USERNAME`: username of the user that generated the PAT.

The image will be pushed to the package registry on Github associated with the Alby organization. We should make this registry public so we can easily pull images from it. 

The image name will be the same as the repository: `regtest-website`, this can easily be changed though.

The images will be tagged according to [this algorithm](https://github.com/mr-smithers-excellent/docker-build-push#tagging-the-image-using-gitops).